### PR TITLE
Support `do` command and necessary foundational components

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,6 +306,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
+ "cc",
  "pkg-config",
  "vcpkg",
 ]
@@ -351,6 +352,7 @@ dependencies = [
  "clap",
  "directories",
  "rusqlite",
+ "uuid",
 ]
 
 [[package]]
@@ -394,6 +396,7 @@ dependencies = [
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
+ "uuid",
 ]
 
 [[package]]
@@ -456,6 +459,15 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,5 @@ edition = "2021"
 chrono = "0.4.38"
 clap = { version = "4.0", features = ["derive"] }
 directories = "5.0.1"
-rusqlite = "0.32.1"
+rusqlite = { version = "0.32.1", features = ["bundled", "uuid"] }
+uuid = { version = "1.11.0", features = ["v7"] }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,8 +1,15 @@
+use crate::database::Database;
 use crate::project::{Project, ProjectDao};
+use crate::session::{Entry, Key, Session};
 use crate::task::{Priority, Status, Task, TaskDao};
-use clap::{Parser, Subcommand};
-use rusqlite::Connection;
-//use crate::session::{Session, SessionDao};
+use chrono::{DateTime, Local, NaiveDateTime, TimeZone, Utc};
+use clap::{Parser, builder::{Styles, styling::Ansi256Color}, Subcommand};
+
+const STYLES: Styles = Styles::styled()
+    .header(Ansi256Color(47).on_default())
+    .usage(Ansi256Color(227).on_default())
+    .literal(Ansi256Color(231).on_default())
+    .placeholder(Ansi256Color(156).on_default());
 
 #[derive(Clone, Subcommand)]
 pub enum Command {
@@ -16,26 +23,28 @@ pub enum Command {
         status: Status,
         #[arg(long, short)]
         due_date: String,
-        //default_value_t [= <expr>]
     },
 
     /// Create a new project
-    #[command(long_about)]
+    #[command(color = clap::ColorChoice::Always, long_about)]
     New { name: String },
 
-    /// List all projects
+    /// List, modify, or delete projects
     #[command(long_about)]
     Project,
 
     /// Switch projects
     #[command(long_about)]
     Switch { name: String },
+
+    /// List, modify, or delete tasks
+    #[command(long_about)]
+    Task,
 }
 
 /// Create and manage projects, set timers, and more!
 #[derive(Parser)]
-#[command(version, long_about)]
-#[command(propagate_version = true)]
+#[command(long_about, styles = STYLES, version)]
 pub struct Args {
     #[command(subcommand)]
     command: Command,
@@ -47,39 +56,101 @@ impl Args {
     }
 }
 
-pub struct Cli<'a> {
-    conn: &'a Connection,
-}
+/// Represents the command line interface, which can interpret parsed arguments.
+pub struct Cli {}
 
-impl<'a> Cli<'a> {
-    pub fn new(conn: &'a Connection) -> Self {
-        Self { conn }
-    }
+/// Command line interface implementation.
+impl Cli {
+    /// Interprets the parse arguments from the command line.
+    pub fn interpret(args: Args) {
+        // Open the database connection. Shared across all data access objects.
+        let database = Database::new();
+        let conn = database.conn();
 
-    pub fn interpret(&self, args: Args) {
+        // Load persistent session data.
+        let session = Session::new(&conn);
+
         match args.command() {
-            Command::Do { what, priority, status, due_date } => {
-                let task = Task::new(what);
-                let task_dao = TaskDao::new(&self.conn);
+            Command::Do {
+                what,
+                priority,
+                status,
+                due_date,
+            } => {
+                // Parse the due date as a local datetime.
+                let due_datetime = due_date + "00:00:00"; // Due at midnight.
+                let naive_due_date_epoch = NaiveDateTime::parse_from_str(&due_datetime, "%m-%d-%Y %H:%M:%S")
+                    .expect("failed to parse due date");
+                let local_due_date_epoch =
+                    Local.from_local_datetime(&naive_due_date_epoch).unwrap();
+
+                // Convert datetimes to UTC before saving. All datetimes are stored in UTC and
+                // converted to the local timezone when interpreting commands.
+                let creation_epoch = Utc::now();
+                let due_date_epoch = DateTime::from(local_due_date_epoch);
+
+                // Get the active project, which the newly created task belongs to.
+                let project_uuid = session.get(Key::ActiveProject);
+
+                // Construct and save the task.
+                let task = Task::new(
+                    what,
+                    priority,
+                    status,
+                    creation_epoch,
+                    due_date_epoch,
+                    project_uuid,
+                );
+                let task_dao = TaskDao::new(&conn);
                 task_dao.add(&task);
             }
             Command::New { name } => {
+                // Create and add a new project to the database.
                 let project = Project::new(name);
-                let project_dao = ProjectDao::new(&self.conn);
+                let project_dao = ProjectDao::new(&conn);
                 project_dao.add(&project);
+
+                // Update the active project.
+                let entry: Entry = Entry::new(Key::ActiveProject, project.take_uuid());
+                session.set(entry);
             }
             Command::Project => {
-                let project_dao = ProjectDao::new(&self.conn);
+                // Get the active project.
+                let project_uuid = session.get(Key::ActiveProject);
+
+                let project_dao = ProjectDao::new(&conn);
                 let projects = project_dao.all();
+
+                // Print all projects, distinguishing the active project. 
                 for project in projects {
-                    println!("{}", project.name());
+                    if project.uuid().eq(&project_uuid) {
+                        println!("* {}", project.name());
+                    } else {
+                        println!("  {}", project.name());
+                    }
                 }
             }
             Command::Switch { name } => {
-                println!("'pom new' was used with name '{name:?}'");
+                // Get the specified project.
+                let project_dao = ProjectDao::new(&conn);
+                let project = project_dao.get(name);
+
+                // Update the active project.
+                let entry: Entry = Entry::new(Key::ActiveProject, project.take_uuid());
+                session.set(entry);
+            }
+            Command::Task => {
+                // Get the active project.
+                let project_uuid = session.get(Key::ActiveProject);
+
+                let task_dao = TaskDao::new(&conn);
+                let tasks = task_dao.all(project_uuid);
+
+                // Print all tasks that belong to the active project.
+                for task in tasks {
+                    println!("{}", task.what());
+                }
             }
         }
     }
 }
-
-

--- a/src/database.rs
+++ b/src/database.rs
@@ -12,15 +12,15 @@ impl Database {
     pub fn new() -> Self {
         // Read the local data path.
         let project_dirs = ProjectDirs::from("com", "ode", "pom").unwrap();
-        let local_data_path = project_dirs.data_local_dir();
+        let data_path = project_dirs.data_dir();
 
         // Create the directory if necessary.
-        if !fs::exists(&local_data_path).unwrap() {
-            fs::create_dir(&local_data_path).unwrap();
+        if !fs::exists(&data_path).unwrap() {
+            fs::create_dir_all(&data_path).unwrap();
         }
 
         // Construct the database path.
-        let database_path = format!("{}/{}", local_data_path.display(), Self::DATABASE_NAME);
+        let database_path = format!("{}/{}", data_path.display(), Self::DATABASE_NAME);
 
         Self { database_path }
     }

--- a/src/database.rs
+++ b/src/database.rs
@@ -1,31 +1,47 @@
 use directories::ProjectDirs;
 use rusqlite::Connection;
-use std::fs;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 
+/// Represents a local database reference for storing projects, tasks, and more.
 pub struct Database {
-    database_path: String,
+    database_path: PathBuf,
 }
 
+/// Local database reference implementation.
 impl Database {
     const DATABASE_NAME: &str = "pomdb.sqlite";
 
+    /// Constructs a new database reference.
     pub fn new() -> Self {
         // Read the local data path.
-        let project_dirs = ProjectDirs::from("com", "ode", "pom").unwrap();
-        let data_path = project_dirs.data_dir();
+        let project_dirs = ProjectDirs::from("com", "Ode", "pom").unwrap();
+        let data_dir = project_dirs.data_dir();
 
-        // Create the directory if necessary.
-        if !fs::exists(&data_path).unwrap() {
-            fs::create_dir_all(&data_path).unwrap();
-        }
+        // Create the data directory if it does not exist.
+        Self::create_dir(data_dir);
 
         // Construct the database path.
-        let database_path = format!("{}/{}", data_path.display(), Self::DATABASE_NAME);
+        let database_path = data_dir.join(Self::DATABASE_NAME);
 
         Self { database_path }
     }
 
+    /// Opens and returns a reference to the database connection.
     pub fn conn(&self) -> Connection {
-        Connection::open(&self.database_path).unwrap()
+        Connection::open(&self.database_path).expect("failed to open database connection")
+    }
+
+    /// Creates a new directory. Panics if an error is encountered.
+    fn create_dir(dir: &Path) {
+        // Create the data directory if necessary.
+        if !fs::exists(&dir)
+            .unwrap_or_else(|_| panic!("failed to check if path `{}` exists", dir.display()))
+        {
+            fs::create_dir_all(&dir)
+                .unwrap_or_else(|_| panic!("failed to create directory: `{}`", dir.display()));
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,21 +6,9 @@ mod task;
 
 use clap::Parser;
 use cli::{Args, Cli};
-use database::Database;
 
 fn main() {
-    // Open the database connection singleton.
-    let database = Database::new();
-    let conn = database.conn();
-
-    // Load the session (active project).
-    // let session_dao = SessionDao::new(&conn);
-    // let session = session_dao.load();
-
-    // Parse the command line arguments.
+    // Parse and interpret the command line arguments.
     let args = Args::parse();
-
-    // Interpret the command line arguments.
-    let cli = Cli::new(&conn);
-    cli.interpret(args);
+    Cli::interpret(args);
 }

--- a/src/project.rs
+++ b/src/project.rs
@@ -1,71 +1,141 @@
 use rusqlite::{params, Connection};
+use uuid::Uuid;
 
+/// Represents a project or goal.
 pub struct Project {
+    uuid: Uuid,
     name: String,
 }
 
+/// Project implementation.
 impl Project {
+    /// Constructs a new project with a guaranteed unique project identifier.
     pub fn new(name: String) -> Self {
-        Self { name }
+        // Generate a unique project identifer based on the current timestamp.
+        let uuid = Uuid::now_v7();
+
+        Self::new_impl(uuid, name)
     }
 
+    /// Returns the unique project identifier.
+    pub fn uuid(&self) -> &Uuid {
+        &self.uuid
+    }
+
+    /// Returns the project name.
     pub fn name(&self) -> &String {
         &self.name
     }
+
+    /// Returns and transfers ownership of the unique project identifier.
+    pub fn take_uuid(&self) -> Uuid {
+        self.uuid
+    }
+
+    /// Constructs a new project.
+    fn new_impl(uuid: Uuid, name: String) -> Self {
+        Self { uuid, name }
+    }
 }
 
+/// Stores and loads project data to and from a database.
 pub struct ProjectDao<'a> {
     conn: &'a Connection,
 }
 
+/// Project data access object implementation.
 impl<'a> ProjectDao<'a> {
+    /// Constructs a new project data access object.
     pub fn new(conn: &'a Connection) -> Self {
-        // Check if the table already exists.
-        let exists = conn
-            .prepare(
-                "SELECT name
-                FROM sqlite_master
-                WHERE type='table'
-                AND name='project'",
-            )
-            .unwrap()
-            .exists([])
-            .unwrap();
-
-        // If not, create the table.
-        if !exists {
-            conn.execute(
-                "CREATE TABLE project (
-                    id   INTEGER PRIMARY KEY,
-                    name TEXT NOT NULL UNIQUE
-                )",
-                (), // Empty list of parameters.
-            )
-            .unwrap();
-        }
+        // Create the `project` table if it does not exist.
+        Self::create_table(&conn);
 
         Self { conn }
     }
 
+    /// Adds a new project to the `project` table.
     pub fn add(&self, project: &Project) {
         self.conn
             .execute(
-                "INSERT INTO project (name) VALUES (?1)",
-                params![project.name],
+                "INSERT INTO project (uuid, name) VALUES (?1, ?2)",
+                params![project.uuid, project.name],
             )
-            .expect("project name is not unique");
+            .expect("failed to add project");
     }
 
+    /// Fetches all projects from the `project` table.
     pub fn all(&self) -> Vec<Project> {
-        let mut stmt = self.conn.prepare("SELECT name FROM project").unwrap();
-        let rows = stmt.query_map([], |row| row.get(0)).unwrap();
+        // Prepare statement to fetch all projects.
+        let mut stmt = self
+            .conn
+            .prepare("SELECT uuid, name FROM project")
+            .expect("failed to prepare fetch-all-projects statement");
+
+        // Fetch and store all projects.
+        let project_iter = stmt
+            .query_map([], |row: &rusqlite::Row<'_>| {
+                Ok(Project::new_impl(row.get(0)?, row.get(1)?))
+            })
+            .expect("failed to fetch all projects");
 
         let mut projects = Vec::new();
-        for name in rows {
-            let project = Project::new(name.unwrap());
-            projects.push(project);
+        for project in project_iter {
+            projects.push(project.expect("failed to extract project from query map"));
         }
 
         projects
+    }
+
+    /// Fetches the project with the specified name.
+    pub fn get(&self, name: String) -> Project {
+        // Prepare statement to fetch specified project.
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT uuid, name
+                FROM    project
+                WHERE   name = ?1")
+            .expect("failed to prepare fetch-project statement");
+
+        // Fetch the specified project.
+        let project_iter = stmt
+            .query_map([&name], |row: &rusqlite::Row<'_>| {
+                Ok(Project::new_impl(row.get(0)?, row.get(1)?))
+            })
+            .expect("failed to fetch project");
+
+        for project in project_iter {
+            return project.expect("failed to extract project from query map");
+        }
+
+        // Project does not exist.
+        panic!("no project found for name: `{:?}`", name);
+    }
+
+    /// Creates the `project` table if it does not exist. Panics if an error is encountered.
+    fn create_table(conn: &Connection) {
+        if !Self::exists(&conn) {
+            conn.execute(
+                "CREATE TABLE project (
+                    uuid BLOB NOT NULL UNIQUE,
+                    name TEXT NOT NULL UNIQUE
+                )",
+                (), // Empty list of parameters.
+            )
+            .expect("failed to create table `project`");
+        }
+    }
+
+    /// Checks if the `project` table exists. Panics if an error is encountered.
+    fn exists(conn: &Connection) -> bool {
+        conn.prepare(
+            "SELECT name
+            FROM    sqlite_master
+            WHERE   type = 'table'
+            AND     name = 'project'",
+        )
+        .expect("failed to prepare check-existence statement")
+        .exists([])
+        .expect("failed to check if table `project` exists")
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,57 +1,149 @@
-// use crate::project::Project;
-// use rusqlite::{params, Connection};
+use rusqlite::{params, Connection};
+use uuid::Uuid;
 
-// pub struct Session {
-//     project: Project,
-// }
+/// Represent a session data entry.
+pub struct Entry {
+    key: Key,
+    value_uuid: Uuid,
+}
 
-// impl Session {
-//     pub fn project(&self) -> &String {
-//         &self.project
-//     }
-// }
+/// Session data entry implementation.
+impl Entry {
+    /// Constructs a new session data entry.
+    pub fn new(key: Key, value_uuid: Uuid) -> Self {
+        Self { key, value_uuid }
+    }
 
-// pub struct SessionDao<'a> {
-//     conn: &'a Connection,
-// }
+    /// Returns the session key.
+    pub fn key(&self) -> Key {
+        self.key
+    }
 
-// impl<'a> SessionDao<'a> {
-//     pub fn new(conn: &'a Connection) -> Self {
-//         // Check if the table already exists.
-//         let exists = conn
-//             .prepare(
-//                 "SELECT name
-//                 FROM sqlite_master
-//                 WHERE type='table'
-//                 AND name='session'",
-//             )
-//             .unwrap()
-//             .exists([])
-//             .unwrap();
+    /// Returns the session value ID, which maps to the primary key
+    pub fn value_uuid(&self) -> &Uuid {
+        &self.value_uuid
+    }
+}
 
-//         // If not, create the table.
-//         // 'value_id' is a foreign key that maps to primary key of any other table in the database.
-//         if !exists {
-//             conn.execute(
-//                 "CREATE TABLE session (
-//                     id       INTEGER PRIMARY KEY,
-//                     key      TEXT NOT NULL UNIQUE,
-//                     value_id INTEGER NOT NULL
-//                 )",
-//                 (), // Empty list of parameters.
-//             )
-//             .unwrap();
-//         }
+// Represents a session data entry key.
+#[derive(Copy, Clone, Debug)]
+pub enum Key {
+    ActiveProject = 0,
+}
 
-//         Self { conn }
-//     }
+/// Stores and loads persistent session data to and from a database. Session data are modeled as
+/// key-value pairs.
+pub struct Session<'a> {
+    conn: &'a Connection,
+}
 
-//     pub fn load(&self) -> Session {
-//         let mut stmt = self.conn.prepare("SELECT name FROM session").unwrap();
-//         let rows = stmt.query_map([], |row| row.get(0)).unwrap();
+/// Session implementation.
+impl<'a> Session<'a> {
+    /// Constructs a new session.
+    pub fn new(conn: &'a Connection) -> Self {
+        // Create the `session` table if it does not exist.
+        Self::create_table(&conn);
 
-//         assert!(rows.count() == 0);
+        Self { conn }
+    }
 
-//         rows
-//     }
-// }
+    /// Fetches the unique value identifier of the specified session data key.
+    pub fn get(&self, key: Key) -> Uuid {
+        // Prepare statement to fetch the unique value identifier.
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT value_uuid
+                FROM    session
+                WHERE   key = ?1",
+            )
+            .expect("failed to prepare fetch-value-uuid statement");
+
+        // Fetch the unique value identifier.
+        let value_uuid_iter = stmt
+            .query_map([key as i64], |row| Ok(row.get(0)?))
+            .expect("failed to fetch unique value identifier");
+
+        // Ensure the unique value identifier exists.
+        for value_uuid in value_uuid_iter {
+            return value_uuid.expect("failed to extract unique value identifier from query map");
+        }
+
+        // Session data key does not exist.
+        panic!("no session data entries found for key: `{:?}`", key);
+    }
+
+    /// Sets a session data entry in the `session` table.
+    pub fn set(&self, entry: Entry) {
+        // Create the session data entry if it does not exist. Otherwise, update the existing
+        // session data entry.
+        if !self.has(entry.key()) {
+            return self.add(entry);
+        }
+
+        self.update(entry)
+    }
+
+    /// Adds a new session data entry to the `session` table.
+    fn add(&self, entry: Entry) {
+        self.conn
+            .execute(
+                "INSERT INTO session (key, value_uuid) VALUES (?1, ?2)",
+                params![entry.key() as i64, entry.value_uuid()],
+            )
+            .expect("project name is not unique");
+    }
+
+    /// Checks if the `session` table has a specified session data key.
+    fn has(&self, key: Key) -> bool {
+        self.conn
+            .prepare(
+                "SELECT key
+                FROM    session
+                WHERE   key = ?1",
+            )
+            .expect("failed to prepare check-existence statement")
+            .exists([key as i64])
+            .expect("failed to check if key exists")
+    }
+
+    /// Updates an existing session data entry.
+    fn update(&self, entry: Entry) {
+        self.conn
+            .prepare(
+                "UPDATE session
+                SET     value_uuid = ?1
+                WHERE   key = ?2",
+            )
+            .expect("failed to prepare update statement")
+            .execute(params![entry.value_uuid(), entry.key() as i64])
+            .expect("failed to update session data entry");
+    }
+
+    /// Creates the `session` table if it does not exist. Panics if an error is encountered.
+    fn create_table(conn: &Connection) {
+        if !Self::exists(&conn) {
+            conn.execute(
+                "CREATE TABLE session (
+                    key        TEXT NOT NULL UNIQUE,
+                    value_uuid BLOB NOT NULL
+                )",
+                (), // Empty list of parameters.
+            )
+            .expect("failed to create table `session`");
+        }
+    }
+
+    /// Checks if the `session` table exists. Panics if an error is encountered.
+    fn exists(conn: &Connection) -> bool {
+        conn.prepare(
+            "SELECT name
+            FROM    sqlite_master
+            WHERE   type = 'table'
+            AND     name = 'session'",
+        )
+        .expect("failed to prepare check-existence statement")
+        .exists([])
+        .expect("failed to check if table `session` exists")
+    }
+}

--- a/src/task.rs
+++ b/src/task.rs
@@ -1,7 +1,9 @@
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, TimeZone, Utc};
 use clap::ValueEnum;
 use rusqlite::{params, Connection};
+use uuid::Uuid;
 
+/// Represents possible task priorities.
 #[derive(Clone, Copy, ValueEnum)]
 pub enum Priority {
     Low = 0,
@@ -10,6 +12,21 @@ pub enum Priority {
     Critical = 3,
 }
 
+/// Priotiy implementation.
+impl Priority {
+    /// Maps a 64-bit integer to the corresponding `Priority` enum.
+    pub fn from_i64(value: i64) -> Priority {
+        match value {
+            0 => Self::Low,
+            1 => Self::Medium,
+            2 => Self::High,
+            3 => Self::Critical,
+            _ => panic!("unknown priority: `{}`", value),
+        }
+    }
+}
+
+/// Represents possible task statuses.
 #[derive(Clone, Copy, ValueEnum)]
 pub enum Status {
     NotStarted = 0,
@@ -17,108 +34,194 @@ pub enum Status {
     Blocked = 2,
 }
 
+/// Status implementation.
+impl Status {
+    /// Maps a 64-bit integer to the corresponding `Status` enum.
+    fn from_i64(value: i64) -> Status {
+        match value {
+            0 => Self::NotStarted,
+            1 => Self::Complete,
+            2 => Self::Blocked,
+            _ => panic!("unknown status: `{}`", value),
+        }
+    }
+}
+
+/// Represents a to-do item with a priority, current status, due date, and more.
 pub struct Task {
+    uuid: Uuid,
     what: String,
     priority: Priority,
     status: Status,
     creation_epoch: DateTime<Utc>,
     due_date_epoch: DateTime<Utc>,
+    project_uuid: Uuid,
 }
 
+/// Task implementation.
 impl Task {
+    /// Constructs a new task with a guaranteed unique task identifier.
     pub fn new(
         what: String,
         priority: Priority,
         status: Status,
         creation_epoch: DateTime<Utc>,
         due_date_epoch: DateTime<Utc>,
+        project_uuid: Uuid,
     ) -> Self {
-        Self {
+        // Generate a unique task identifer based on the current timestamp.
+        let uuid = Uuid::now_v7();
+
+        Self::new_impl(
+            uuid,
             what,
             priority,
             status,
             creation_epoch,
             due_date_epoch,
-        }
+            project_uuid,
+        )
     }
 
-    // pub fn what(&self) -> &String {
-    //     &self.what
-    // }
+    /// Returns the task objective.
+    pub fn what(&self) -> &String {
+        &self.what
+    }
+
+    /// Constructs a new task.
+    fn new_impl(
+        uuid: Uuid,
+        what: String,
+        priority: Priority,
+        status: Status,
+        creation_epoch: DateTime<Utc>,
+        due_date_epoch: DateTime<Utc>,
+        project_uuid: Uuid,
+    ) -> Self {
+        Self {
+            uuid,
+            what,
+            priority,
+            status,
+            creation_epoch,
+            due_date_epoch,
+            project_uuid,
+        }
+    }
 }
 
+/// Stores and loads task data to and from a database.
 pub struct TaskDao<'a> {
     conn: &'a Connection,
 }
 
+/// Task data access object implementation.
 impl<'a> TaskDao<'a> {
+    /// Constructs a new task data access object.
     pub fn new(conn: &'a Connection) -> Self {
-        // Check if the table already exists.
-        let exists = conn
-            .prepare(
-                "SELECT name
-                FROM    sqlite_master
-                WHERE   type='table'
-                AND     name='task'",
-            )
-            .unwrap()
-            .exists([])
-            .unwrap();
-
-        // If not, create the table.
-        if !exists {
-            conn.execute(
-                "CREATE TABLE task (
-                    id             INTEGER PRIMARY KEY,
-                    what           TEXT NOT NULL UNIQUE,
-                    priority       INTEGER NOT NULL,
-                    status         INTEGER NOT NULL,
-                    creation_epoch INTEGER NOT NULL,
-                    due_date_epoch INTEGER NOT NULL
-                )",
-                (), // Empty list of parameters.
-            )
-            .unwrap();
-        }
+        // Create the `task` table if it does not exist.
+        Self::create_table(&conn);
 
         Self { conn }
     }
 
+    /// Adds a new task to the `task` table.
     pub fn add(&self, task: &Task) {
         self.conn
             .execute(
                 "INSERT INTO task (
+                    uuid,
                     what,
                     priority,
                     status,
                     creation_epoch, 
-                    due_date_epoch
-                ) VALUES (?1, ?2, ?3, ?4, ?5)",
+                    due_date_epoch,
+                    project_uuid
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
                 params![
+                    task.uuid,
                     task.what,
-                    task.priority as u8,
-                    task.status as u8,
-                    Self::to_milliseconds(&task.creation_epoch),
-                    Self::to_milliseconds(&task.due_date_epoch)
+                    task.priority as i64,
+                    task.status as i64,
+                    task.creation_epoch.timestamp(),
+                    task.due_date_epoch.timestamp(),
+                    task.project_uuid
                 ],
             )
-            .unwrap();
+            .expect("failed to add task");
     }
 
-    // pub fn all(&self) -> Vec<Item> {
-    //     let mut stmt = self.conn.prepare("SELECT message FROM task").unwrap();
-    //     let rows = stmt.query_map([], |row| row.get(0)).unwrap();
+    /// Fetches all tasks from the `task` table.
+    pub fn all(&self, project_uuid: Uuid) -> Vec<Task> {
+        // Prepare statement to fetch all tasks.
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT
+                    uuid,
+                    what,
+                    priority,
+                    status,
+                    creation_epoch,
+                    due_date_epoch,
+                    project_uuid
+                FROM task
+                WHERE project_uuid = ?1",
+            )
+            .expect("failed to prepare fetch-all-tasks statement");
 
-    //     let mut tasks = Vec::new();
-    //     for name in rows {
-    //         let item = Item::new(name.unwrap());
-    //         items.push(item);
-    //     }
+        // Fetch and store all tasks.
+        let task_iter = stmt
+            .query_map([project_uuid], |row| {
+                Ok(Task::new_impl(
+                    row.get(0)?,
+                    row.get(1)?,
+                    Priority::from_i64(row.get(2)?),
+                    Status::from_i64(row.get(3)?),
+                    Utc.timestamp_opt(row.get(4)?, 0).unwrap(),
+                    Utc.timestamp_opt(row.get(5)?, 0).unwrap(),
+                    row.get(6)?,
+                ))
+            })
+            .expect("failed to fetch all tasks");
 
-    //     items
-    // }
+        let mut tasks = Vec::new();
+        for task in task_iter {
+            tasks.push(task.expect("failed to extract task from query map"));
+        }
 
-    fn to_milliseconds(datetime: &DateTime<Utc>) -> i64 {
-        datetime.timestamp()
+        tasks
+    }
+
+    /// Creates the `task` table if it does not exist. Panics if an error is encountered.
+    fn create_table(conn: &Connection) {
+        if !Self::exists(&conn) {
+            conn.execute(
+                "CREATE TABLE task (
+                    uuid           BLOB NOT NULL UNIQUE,
+                    what           TEXT NOT NULL,
+                    priority       INTEGER NOT NULL,
+                    status         INTEGER NOT NULL,
+                    creation_epoch INTEGER NOT NULL,
+                    due_date_epoch INTEGER NOT NULL,
+                    project_uuid   BLOB NOT NULL
+                )",
+                (), // Empty list of parameters.
+            )
+            .expect("failed to create table `task`");
+        }
+    }
+
+    /// Checks if the `task` table exists. Panics if an error is encountered.
+    fn exists(conn: &Connection) -> bool {
+        conn.prepare(
+            "SELECT name
+            FROM    sqlite_master
+            WHERE   type = 'table'
+            AND     name = 'task'",
+        )
+        .expect("failed to prepare check-existence statement")
+        .exists([])
+        .expect("failed to check if table `task` exists")
     }
 }

--- a/src/task.rs
+++ b/src/task.rs
@@ -2,19 +2,19 @@ use chrono::{DateTime, Utc};
 use clap::ValueEnum;
 use rusqlite::{params, Connection};
 
-#[derive(Clone, ValueEnum)]
+#[derive(Clone, Copy, ValueEnum)]
 pub enum Priority {
-    Critical,
-    Low,
-    Medium,
-    High,
+    Low = 0,
+    Medium = 1,
+    High = 2,
+    Critical = 3,
 }
 
-#[derive(Clone, ValueEnum)]
+#[derive(Clone, Copy, ValueEnum)]
 pub enum Status {
-    Blocked,
-    Complete,
-    NotStarted,
+    NotStarted = 0,
+    Complete = 1,
+    Blocked = 2,
 }
 
 pub struct Task {
@@ -26,17 +26,25 @@ pub struct Task {
 }
 
 impl Task {
-    pub fn new(what: String) -> Self {
-        let priority = Priority::Low;
-        let status = Status::NotStarted;
-        let creation_epoch = Utc::now();
-        let due_date_epoch = Utc::now();
-        Self { what, priority, status, creation_epoch, due_date_epoch }
+    pub fn new(
+        what: String,
+        priority: Priority,
+        status: Status,
+        creation_epoch: DateTime<Utc>,
+        due_date_epoch: DateTime<Utc>,
+    ) -> Self {
+        Self {
+            what,
+            priority,
+            status,
+            creation_epoch,
+            due_date_epoch,
+        }
     }
 
-    pub fn what(&self) -> &String {
-        &self.what
-    }
+    // pub fn what(&self) -> &String {
+    //     &self.what
+    // }
 }
 
 pub struct TaskDao<'a> {
@@ -62,10 +70,10 @@ impl<'a> TaskDao<'a> {
             conn.execute(
                 "CREATE TABLE task (
                     id             INTEGER PRIMARY KEY,
-                    what           TEXT NOT NULL UNIQUE
-                    priority       INTEGER NOT NULL
-                    status         INTEGER NOT NULL
-                    creation_epoch INTEGER NOT NULL
+                    what           TEXT NOT NULL UNIQUE,
+                    priority       INTEGER NOT NULL,
+                    status         INTEGER NOT NULL,
+                    creation_epoch INTEGER NOT NULL,
                     due_date_epoch INTEGER NOT NULL
                 )",
                 (), // Empty list of parameters.
@@ -78,7 +86,22 @@ impl<'a> TaskDao<'a> {
 
     pub fn add(&self, task: &Task) {
         self.conn
-            .execute("INSERT INTO task (what) VALUES (?1)", params![task.what])
+            .execute(
+                "INSERT INTO task (
+                    what,
+                    priority,
+                    status,
+                    creation_epoch, 
+                    due_date_epoch
+                ) VALUES (?1, ?2, ?3, ?4, ?5)",
+                params![
+                    task.what,
+                    task.priority as u8,
+                    task.status as u8,
+                    Self::to_milliseconds(&task.creation_epoch),
+                    Self::to_milliseconds(&task.due_date_epoch)
+                ],
+            )
             .unwrap();
     }
 
@@ -94,4 +117,8 @@ impl<'a> TaskDao<'a> {
 
     //     items
     // }
+
+    fn to_milliseconds(datetime: &DateTime<Utc>) -> i64 {
+        datetime.timestamp()
+    }
 }


### PR DESCRIPTION
📜 **Tickets**

Issue: n/a

✨ **Description**

This PR adds support for the `do` command along with other foundational components necessary to provide the basic functionality of the `do` command, such as the database, persistent session, projects, and more.

🧪 **Testing**

☒ (minimum) User acceptance tests
☐ Integration tests
☐ Unit tests