### PR TITLE
Support quest modifications

### DIFF
--- a/src/quest.rs
+++ b/src/quest.rs
@@ -80,12 +80,17 @@ impl Quest {
         &self.objective
     }
 
+    /// Borrows a mutable reference to the objective.
+    pub fn objective_mut(&mut self) -> &mut String {
+        &mut self.objective
+    }
+
     /// Copies the status.
     pub fn status(&self) -> Status {
         self.status
     }
 
-    /// Borrows a mutable reference of the status.
+    /// Borrows a mutable reference to the status.
     pub fn status_mut(&mut self) -> &mut Status {
         &mut self.status
     }
@@ -93,6 +98,11 @@ impl Quest {
     /// Copies the tier.
     pub fn tier(&self) -> Tier {
         self.tier
+    }
+
+    /// Borrows a mutable reference to the tier.
+    pub fn tier_mut(&mut self) -> &mut Tier {
+        &mut self.tier
     }
 
     /// Constructs a new quest.


### PR DESCRIPTION
📜 **Tickets**

Issue: n/a

✨ **Description**

This PR adds the `quest modify` command, which allows for basic modifications to the quest objective, status, and tier. Updating the quest chain identifier will be implemented in a follow-up PR due to its complexity.

This feature requires redesigning the `quest log` command, which has the assumption that a given main quest will always have an identifier less than its secondary quests.  Clearly, this assumption no longer holds if the chain identifier can be freely updated by the user.

🧪 **Testing**

☒ (minimum) User acceptance tests
☐ Integration tests
☐ Unit tests